### PR TITLE
compiler directives as in original FastMM4

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -1023,6 +1023,13 @@ interface
 
 {$Include FastMM4Options.inc}
 
+{$RANGECHECKS OFF}
+{$BOOLEVAL OFF}
+{$OVERFLOWCHECKS OFF}
+{$OPTIMIZATION ON}
+{$TYPEDADDRESS OFF}
+{$LONGSTRINGS ON}
+
 {Compiler version defines}
 {$ifndef fpc}
   {$ifndef BCB}


### PR DESCRIPTION
especially "rangecheck off" is needed for GetMemoryManagerState to avoid exception in FullDebugMode